### PR TITLE
Remake converter

### DIFF
--- a/hateblo-math-convert.rb
+++ b/hateblo-math-convert.rb
@@ -121,8 +121,15 @@ class HatebloMathConverter
   def write_text
     File.open(@file_name, 'w') do |f|
       @target_text.each do |line|
-        f.write(line)
-        f.write("\n")
+        if line.match(@reg_exp_begin)
+          f.print("\n")
+          f.print(line)
+        elsif line.match(@reg_exp_end)
+          f.print(line)
+          f.print("\n")
+        else
+          f.print(line)
+        end
       end
     end
   end


### PR DESCRIPTION
大幅に作り直した.

* 数式表現のあるものとないものを完全に分離
* はてな記法使用時には不要なエスケープをしないオプションを追加 (`--hatena` オプション)
* `[]` を `\[\]` にエスケープするのを追加
* 標準出力は改行が多いが, ファイル書き込みは必要以上の改行をしないようになっている.